### PR TITLE
RIL: Fix manual network selection with old modem

### DIFF
--- a/src/java/com/android/internal/telephony/RIL.java
+++ b/src/java/com/android/internal/telephony/RIL.java
@@ -175,6 +175,7 @@ public class RIL extends BaseCommands implements CommandsInterface {
 
     final Integer mPhoneId;
     private List<String> mOldRilFeatures;
+    private boolean mUseOldMncMccFormat;
 
     /* default work source which will blame phone process */
     protected WorkSource mRILDefaultWorkSource;
@@ -459,6 +460,9 @@ public class RIL extends BaseCommands implements CommandsInterface {
 
         final String oldRilFeatures = SystemProperties.get("ro.telephony.ril.config", "");
         mOldRilFeatures = Arrays.asList(oldRilFeatures.split(","));
+
+        mUseOldMncMccFormat = SystemProperties.getBoolean(
+                "ro.telephony.use_old_mnc_mcc_format", false);
 
         ConnectivityManager cm = (ConnectivityManager)context.getSystemService(
                 Context.CONNECTIVITY_SERVICE);
@@ -1682,6 +1686,10 @@ public class RIL extends BaseCommands implements CommandsInterface {
         if (radioProxy != null) {
             RILRequest rr = obtainRequest(RIL_REQUEST_SET_NETWORK_SELECTION_MANUAL, result,
                     mRILDefaultWorkSource);
+
+            if (mUseOldMncMccFormat && !TextUtils.isEmpty(operatorNumeric)) {
+                operatorNumeric += "+";
+            }
 
             if (RILJ_LOGD) {
                 riljLog(rr.serialString() + "> " + requestToString(rr.mRequest)

--- a/src/java/com/android/internal/telephony/RadioResponse.java
+++ b/src/java/com/android/internal/telephony/RadioResponse.java
@@ -1797,8 +1797,12 @@ public class RadioResponse extends IRadioResponse.Stub {
         if (rr != null) {
             ArrayList<OperatorInfo> ret = new ArrayList<OperatorInfo>();
             for (int i = 0; i < networkInfos.size(); i++) {
+                String operatorNumeric = networkInfos.get(i).operatorNumeric;
+                if (operatorNumeric != null) {
+                    operatorNumeric = operatorNumeric.split("\\+")[0];
+                }
                 ret.add(new OperatorInfo(networkInfos.get(i).alphaLong,
-                        networkInfos.get(i).alphaShort, networkInfos.get(i).operatorNumeric,
+                        networkInfos.get(i).alphaShort, operatorNumeric,
                         convertOpertatorInfoToString(networkInfos.get(i).status)));
             }
             if (responseInfo.error == RadioError.NONE) {


### PR DESCRIPTION
 * Old modem sends and applies mccmnc+network type, but new aosp
   telephony uses only digits.
 * Manually cut or append the "+" and strings after that to work around.

Change-Id: I1015e6c0d6afdc0c03d70e9491d49331703eddcc